### PR TITLE
Prometheus: Skip untested fields

### DIFF
--- a/vedirect/prometheus.py
+++ b/vedirect/prometheus.py
@@ -112,6 +112,9 @@ class Exporter:
         self._blocks.labels(ser, pid).inc()
 
         for label, value in fields.items():
+            if label not in self._metrics:
+                continue
+
             gauge = self._metrics[label]
             if isinstance(value, pint.Quantity):
                 f = self._filters.setdefault(label, Filter())


### PR DESCRIPTION
I ran in to an error when trying to enable Prometheus exports with a _SmartSolar MPPT 100|20 48V_, which was including the `OR` (Off Reason) field, which does not appear to be fully implemented in this project.

I wasn't quite sure the best way to implement this field, as I believe `OR` can return multiple values simultaneously, so went for a lighter touch workaround of having un-tested fields skipped with Prometheus exports.